### PR TITLE
Added API for context aware config resource injection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version>30</version>
         <relativePath />
     </parent>
-    
+
     <artifactId>org.apache.sling.caconfig.api</artifactId>
     <packaging>bundle</packaging>
     <version>1.1.3-SNAPSHOT</version>
@@ -39,7 +39,7 @@
         <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-caconfig-api.git</url>
       <tag>HEAD</tag>
   </scm>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -66,6 +66,12 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
             <version>2.9.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.models.api</artifactId>
+            <version>1.3.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/caconfig/models/via/ContextAwareConfigResource.java
+++ b/src/main/java/org/apache/sling/caconfig/models/via/ContextAwareConfigResource.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.caconfig.models.via;
+
+import org.apache.sling.models.annotations.ViaProviderType;
+
+/**
+ * Marker class for using the JavaBean @Via provider.
+ */
+public class ContextAwareConfigResource implements ViaProviderType {
+}

--- a/src/main/java/org/apache/sling/caconfig/models/via/package-info.java
+++ b/src/main/java/org/apache/sling/caconfig/models/via/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * API for accessing context-aware configuration.
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.apache.sling.caconfig.models.via;


### PR DESCRIPTION
Makes the following possible:

`@model(adaptables = {SlingHttpServletRequest.class, Resource.class}, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
public class SampleModel {

@Via(type= ContextAwareConfigResource.class, value = "config")
@ValueMapValue
private String propertyTest;

public String getPropertyTest() {
    return propertyTest;
}
}`

Use via to point to context aware config resource, to inject valuemap values.
Tested it locally and works fine with latest versions.
What do you think?